### PR TITLE
Fix file creation bug caused by invalid size of dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea
-/sfs.img
+/*.img


### PR DESCRIPTION
The `size` in inode for directory is only valid for normal file. (Althrough in this implement it is also valid for directory)